### PR TITLE
update parsing for terraform v0.14

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -180,7 +180,7 @@ if [[ $COMMAND == 'plan' ]]; then
   # Meaning: 0 = Terraform plan succeeded with no changes. 2 = Terraform plan succeeded with changes.
   # Actions: Strip out the refresh section (everything before the 72 '-' characters) and build PR comment.
   if [[ $EXIT_CODE -eq 0 || $EXIT_CODE -eq 2 ]]; then
-    CLEAN_PLAN=$(echo "$INPUT" | sed -nr '/-{72}/,/-{72}/{ /-{72}/d; p }') # Strip refresh section
+    CLEAN_PLAN=$(echo "$INPUT" | sed -n '/Refreshing state\.\.\./!p') # Strip refresh section
     CLEAN_PLAN=${CLEAN_PLAN::65300} # GitHub has a 65535-char comment limit - truncate plan, leaving space for comment wrapper
     CLEAN_PLAN=$(echo "$CLEAN_PLAN" | sed -E 's/^([[:blank:]]*)([-+~])/\2\1/g') # Move any diff characters to start of line
     PR_COMMENT="### Terraform \`plan\` Succeeded for Workspace: \`$WORKSPACE\`


### PR DESCRIPTION
Prior version of `terraform plan` output something like 

```
<...>
some_resource: Refreshing state... [id=some_resource]

------------------------------------------------------------------------

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  ~ update in-place
  - destroy
<...>
------------------------------------------------------------------------
```

But latest terraform no longer output the first `------` line:
```
<...>
some_resource: Refreshing state... [id=some_resource]

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  ~ update in-place
  - destroy
<...>
------------------------------------------------------------------------
```

So the parsing strips all the actual diff.

This PR fixes the parsing by stripping out the lines containing `Refreshing state...` instead of looking for content between the `----` lines.