### PR TITLE
New sed refresh strip on plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.3.0
+
+- Bump to Terraform v0.14.9 internally (only affects `fmt`)
+- Fix output truncation in Terraform v0.14 and above
+
 ## v1.2.0
 
 - Bump to Terraform v0.14.5 internally (only affects `fmt`)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hashicorp/terraform:0.14.5
+FROM hashicorp/terraform:0.14.9
 
 LABEL repository="https://github.com/robburger/terraform-pr-commenter" \
       homepage="https://github.com/robburger/terraform-pr-commenter" \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -181,10 +181,9 @@ if [[ $COMMAND == 'plan' ]]; then
 
   # Exit Code: 0, 2
   # Meaning: 0 = Terraform plan succeeded with no changes. 2 = Terraform plan succeeded with changes.
-  # Actions: Strip out the refresh section, ignore everything after the 72 dashes, format, colourise and build PR comment.
+  # Actions: Strip out the refresh section (everything before the actual plan output), format, colourise and build PR comment.
   if [[ $EXIT_CODE -eq 0 || $EXIT_CODE -eq 2 ]]; then
-    CLEAN_PLAN=$(echo "$INPUT" | sed -n '/Refreshing state\.\.\./!p') # Strip refresh section
-    CLEAN_PLAN=$(echo "$CLEAN_PLAN" | sed -nr '/-{72}/q;p') # Ignore everything after the 72 dashes (happens when saving a plan to file)
+    CLEAN_PLAN=$(echo "$INPUT" | sed -n '/^(An execution plan has been generated and is shown below.|No changes. Infrastructure is up-to-date.)$/,$!d') # Strip refresh section
     CLEAN_PLAN=${CLEAN_PLAN::65300} # GitHub has a 65535-char comment limit - truncate plan, leaving space for comment wrapper
     CLEAN_PLAN=$(echo "$CLEAN_PLAN" | sed -r 's/^([[:blank:]]*)([-+~])/\2\1/g') # Move any diff characters to start of line
     if [[ $COLOURISE == 'true' ]]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -181,9 +181,10 @@ if [[ $COMMAND == 'plan' ]]; then
 
   # Exit Code: 0, 2
   # Meaning: 0 = Terraform plan succeeded with no changes. 2 = Terraform plan succeeded with changes.
-  # Actions: Strip out the refresh section (everything before the actual plan output), format, colourise and build PR comment.
+  # Actions: Strip out the refresh section and everything after the 72 dashes, format, colourise and build PR comment.
   if [[ $EXIT_CODE -eq 0 || $EXIT_CODE -eq 2 ]]; then
     CLEAN_PLAN=$(echo "$INPUT" | sed -r '/^(An execution plan has been generated and is shown below.|No changes. Infrastructure is up-to-date.)$/,$!d') # Strip refresh section
+    CLEAN_PLAN=$(echo "$CLEAN_PLAN" | sed -nr '/-{72}/q;p') # Ignore everything after the 72 dashes (happens when saving a plan to file)
     CLEAN_PLAN=${CLEAN_PLAN::65300} # GitHub has a 65535-char comment limit - truncate plan, leaving space for comment wrapper
     CLEAN_PLAN=$(echo "$CLEAN_PLAN" | sed -r 's/^([[:blank:]]*)([-+~])/\2\1/g') # Move any diff characters to start of line
     if [[ $COLOURISE == 'true' ]]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -183,7 +183,7 @@ if [[ $COMMAND == 'plan' ]]; then
   # Meaning: 0 = Terraform plan succeeded with no changes. 2 = Terraform plan succeeded with changes.
   # Actions: Strip out the refresh section (everything before the actual plan output), format, colourise and build PR comment.
   if [[ $EXIT_CODE -eq 0 || $EXIT_CODE -eq 2 ]]; then
-    CLEAN_PLAN=$(echo "$INPUT" | sed -n '/^(An execution plan has been generated and is shown below.|No changes. Infrastructure is up-to-date.)$/,$!d') # Strip refresh section
+    CLEAN_PLAN=$(echo "$INPUT" | sed -r '/^(An execution plan has been generated and is shown below.|No changes. Infrastructure is up-to-date.)$/,$!d') # Strip refresh section
     CLEAN_PLAN=${CLEAN_PLAN::65300} # GitHub has a 65535-char comment limit - truncate plan, leaving space for comment wrapper
     CLEAN_PLAN=$(echo "$CLEAN_PLAN" | sed -r 's/^([[:blank:]]*)([-+~])/\2\1/g') # Move any diff characters to start of line
     if [[ $COLOURISE == 'true' ]]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -181,7 +181,7 @@ if [[ $COMMAND == 'plan' ]]; then
 
   # Exit Code: 0, 2
   # Meaning: 0 = Terraform plan succeeded with no changes. 2 = Terraform plan succeeded with changes.
-  # Actions: Strip out the refresh section and everything after the 72 dashes, format, colourise and build PR comment.
+  # Actions: Strip out the refresh section, ignore everything after the 72 dashes, format, colourise and build PR comment.
   if [[ $EXIT_CODE -eq 0 || $EXIT_CODE -eq 2 ]]; then
     CLEAN_PLAN=$(echo "$INPUT" | sed -r '/^(An execution plan has been generated and is shown below.|No changes. Infrastructure is up-to-date.)$/,$!d') # Strip refresh section
     CLEAN_PLAN=$(echo "$CLEAN_PLAN" | sed -nr '/-{72}/q;p') # Ignore everything after the 72 dashes (happens when saving a plan to file)


### PR DESCRIPTION
## Overview

Resolve the `plan` output sometimes being truncated entirely.

Fixes #5 

## Details

Versions of Terraform prior to v0.14 had 72 `-`'s after the refresh section and at the end of a plan. Newer versions don't have the dash characters.

Seems that the only two consistent phrases coming up are *"An execution plan has been generated and is shown below."* and *"No changes. Infrastructure is up-to-date."* - so we'll try and use those to grab our plan.

**Example: v0.13 Output**
```
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

data.aws_region.current: Refreshing state... [id=something]
data.aws_caller_identity.current: Refreshing state... [id=something]
...
------------------------------------------------------------------------

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create
  ~ update in-place
-/+ destroy and then create replacement

Terraform will perform the following actions:

<snip>

Plan: 1 to add, 1 to change, 1 to destroy.

------------------------------------------------------------------------
```

**Example: 0.14 Output**
```
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

data.aws_region.current: Refreshing state... [id=something]
data.aws_caller_identity.current: Refreshing state... [id=something]
...

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create
  ~ update in-place
-/+ destroy and then create replacement

Terraform will perform the following actions:

<snip>

Plan: 1 to add, 1 to change, 1 to destroy.
```