### PR TITLE
Change sed search string for plan output

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -184,7 +184,7 @@ if [[ $COMMAND == 'plan' ]]; then
   # Actions: Strip out the refresh section, ignore everything after the 72 dashes, format, colourise and build PR comment.
   if [[ $EXIT_CODE -eq 0 || $EXIT_CODE -eq 2 ]]; then
     CLEAN_PLAN=$(echo "$INPUT" | sed -r '/^(An execution plan has been generated and is shown below.|Terraform used the selected providers to generate the following execution|No changes. Infrastructure is up-to-date.)$/,$!d') # Strip refresh section
-    CLEAN_PLAN=$(echo "$CLEAN_PLAN" | sed -nr '/[-─]{72}/q;p') # Ignore everything after the 72 dashes/box-chars (happens when saving a plan to file)
+    CLEAN_PLAN=$(echo "$CLEAN_PLAN" | sed -r '/Plan: /q') # Ignore everything after plan summary
     CLEAN_PLAN=${CLEAN_PLAN::65300} # GitHub has a 65535-char comment limit - truncate plan, leaving space for comment wrapper
     CLEAN_PLAN=$(echo "$CLEAN_PLAN" | sed -r 's/^([[:blank:]]*)([-+~])/\2\1/g') # Move any diff characters to start of line
     if [[ $COLOURISE == 'true' ]]; then


### PR DESCRIPTION
The change to the new "box drawing" character in TF v0.15 causes occasional weird characters to be interpreted in the script. i.e. when the horizontal line is processed by the script, sometimes characters randomly change, and therefore the line and everything after it is not removed by the `sed` expression. Re-running the build either causes different characters to be changed, or none at all...and therefore it appears to work.

Instead of trying to resolve the randomly appearing characters, this PR simply changes the `sed` expression to print everything up to and including the plan summary (`Plan: ...`) and then quit.