### PR TITLE
Bump Base Docker Image to v1.4.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hashicorp/terraform:1.0.6
+FROM hashicorp/terraform:1.4.5
 
 LABEL repository="https://github.com/robburger/terraform-pr-commenter" \
       homepage="https://github.com/robburger/terraform-pr-commenter" \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -184,7 +184,6 @@ if [[ $COMMAND == 'plan' ]]; then
   # Actions: Strip out the refresh section, ignore everything after the 72 dashes, format, colourise and build PR comment.
   if [[ $EXIT_CODE -eq 0 || $EXIT_CODE -eq 2 ]]; then
     CLEAN_PLAN=$(echo "$INPUT" | sed -r '/^(An execution plan has been generated and is shown below.|Terraform used the selected providers to generate the following execution|No changes. Infrastructure is up-to-date.|No changes. Your infrastructure matches the configuration.|Note: Objects have changed outside of Terraform)$/,$!d') # Strip refresh section
-    CLEAN_PLAN=$(echo "$CLEAN_PLAN" | sed -r '/Plan: /q') # Ignore everything after plan summary
     CLEAN_PLAN=${CLEAN_PLAN::65300} # GitHub has a 65535-char comment limit - truncate plan, leaving space for comment wrapper
     CLEAN_PLAN=$(echo "$CLEAN_PLAN" | sed -r 's/^([[:blank:]]*)([-+~])/\2\1/g') # Move any diff characters to start of line
     if [[ $COLOURISE == 'true' ]]; then


### PR DESCRIPTION
Bumps the base Docker image to v1.4.5 which solves an issue with the current version of `curl` being used, see below.

```
INFO: Looking for an existing plan PR comment.
Error relocating /usr/bin/curl: curl_easy_nextheader: symbol not found
Error relocating /usr/bin/curl: curl_easy_header: symbol not found
INFO: No existing plan PR comment found.
INFO: Adding plan comment to PR.
Error relocating /usr/bin/curl: curl_easy_nextheader: symbol not found
Error relocating /usr/bin/curl: curl_easy_header: symbol not found
```

It might also be worth pinning the `curl` version (and the versions of the other packages used) so this doesn't happen in the future 😄 