### PR TITLE
[NO-TICKET] Fix argument list too long error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hashicorp/terraform:1.4.5
+FROM hashicorp/terraform:1.5.7
 
 LABEL repository="https://github.com/robburger/terraform-pr-commenter" \
       homepage="https://github.com/robburger/terraform-pr-commenter" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hashicorp/terraform:1.0.11
+FROM hashicorp/terraform:1.2.6
 
 LABEL repository="https://github.com/robburger/terraform-pr-commenter" \
       homepage="https://github.com/robburger/terraform-pr-commenter" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hashicorp/terraform:1.5.7
+FROM hashicorp/terraform:latest
 
 LABEL repository="https://github.com/robburger/terraform-pr-commenter" \
       homepage="https://github.com/robburger/terraform-pr-commenter" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hashicorp/terraform:1.2.6
+FROM hashicorp/terraform:1.4.5
 
 LABEL repository="https://github.com/robburger/terraform-pr-commenter" \
       homepage="https://github.com/robburger/terraform-pr-commenter" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hashicorp/terraform:1.0.6
+FROM hashicorp/terraform:1.0.11
 
 LABEL repository="https://github.com/robburger/terraform-pr-commenter" \
       homepage="https://github.com/robburger/terraform-pr-commenter" \

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: 'The type of comment. Options: [fmt, init, plan]'
     required: true
   commenter_input:
-    description: 'The comment to post from a previous step output'
+    description: 'The comment to post from a previous step output. Plan must be a file.'
     required: true
   commenter_exitcode:
     description: 'The exit code from a previous step output'

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: 'The type of comment. Options: [fmt, init, plan]'
     required: true
   commenter_input:
-    description: 'The comment to post from a previous step output. Plan must be a file.'
+    description: 'The comment to post from a previous step output. Provide full plan as ENV instead.'
     required: true
   commenter_exitcode:
     description: 'The exit code from a previous step output'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -183,7 +183,7 @@ if [[ $COMMAND == 'plan' ]]; then
   # Meaning: 0 = Terraform plan succeeded with no changes. 2 = Terraform plan succeeded with changes.
   # Actions: Strip out the refresh section, ignore everything after the 72 dashes, format, colourise and build PR comment.
   if [[ $EXIT_CODE -eq 0 || $EXIT_CODE -eq 2 ]]; then
-    CLEAN_PLAN=$(echo "$INPUT" | sed -r '/^(An execution plan has been generated and is shown below.|Terraform used the selected providers to generate the following execution|No changes. Infrastructure is up-to-date.|No changes. Your infrastructure matches the configuration.|Note: Objects have changed outside of Terraform)$/,$!d') # Strip refresh section
+    CLEAN_PLAN=$(cat "$INPUT" | sed -r '/^(An execution plan has been generated and is shown below.|Terraform used the selected providers to generate the following execution|No changes. Infrastructure is up-to-date.|No changes. Your infrastructure matches the configuration.|Note: Objects have changed outside of Terraform)$/,$!d') # Strip refresh section
     CLEAN_PLAN=$(echo "$CLEAN_PLAN" | sed -r '/Plan: /q') # Ignore everything after plan summary
     PLAN_SUMMARY=$(echo "$CLEAN_PLAN" | grep -E '^(Plan: )|(No changes. Your infrastructure matches the configuration.)')
     if grep -q "Note: Objects have changed outside of Terraform" <<< "$CLEAN_PLAN"; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -178,12 +178,15 @@ if [[ $COMMAND == 'plan' ]]; then
   else
     echo -e "\033[34;1mINFO:\033[0m No existing plan PR comment found."
   fi
+  if [ -z "$INPUT" ]; then
+    INPUT=$FULL_PLAN
+  fi
 
   # Exit Code: 0, 2
   # Meaning: 0 = Terraform plan succeeded with no changes. 2 = Terraform plan succeeded with changes.
   # Actions: Strip out the refresh section, ignore everything after the 72 dashes, format, colourise and build PR comment.
   if [[ $EXIT_CODE -eq 0 || $EXIT_CODE -eq 2 ]]; then
-    CLEAN_PLAN=$(cat "$INPUT" | sed -r '/^(An execution plan has been generated and is shown below.|Terraform used the selected providers to generate the following execution|No changes. Infrastructure is up-to-date.|No changes. Your infrastructure matches the configuration.|Note: Objects have changed outside of Terraform)$/,$!d') # Strip refresh section
+    CLEAN_PLAN=$(echo "$INPUT" | sed -r '/^(An execution plan has been generated and is shown below.|Terraform used the selected providers to generate the following execution|No changes. Infrastructure is up-to-date.|No changes. Your infrastructure matches the configuration.|Note: Objects have changed outside of Terraform)$/,$!d') # Strip refresh section
     CLEAN_PLAN=$(echo "$CLEAN_PLAN" | sed -r '/Plan: /q') # Ignore everything after plan summary
     PLAN_SUMMARY=$(echo "$CLEAN_PLAN" | grep -E '^(Plan: )|(No changes. Your infrastructure matches the configuration.)')
     if grep -q "Note: Objects have changed outside of Terraform" <<< "$CLEAN_PLAN"; then


### PR DESCRIPTION
NO-TICKET

**Why needed:** Infrastructure CI pipelines fail with "Argument list too long" error when terraform plan output is large. The plan output is passed via FULL_PLAN environment variable, which exceeds OS ARG_MAX limits when Docker starts.

**Why this approach:** Reading from a file path (FULL_PLAN_FILE) instead of an env var avoids the argument size limit entirely. The file is written to the GitHub workspace in the calling workflow and mounted into the Docker container at /github/workspace. This approach is backwards-compatible - if FULL_PLAN_FILE is not set, falls back to FULL_PLAN env var.

## Test plan
- [ ] Verify infrastructure PR with large terraform plan passes CI
- [ ] Verify backwards compatibility with workflows not using FULL_PLAN_FILE